### PR TITLE
Route error/system notices away from the public alerts channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,12 @@ BATCH_SIZE=10
 REASONING_EFFORT_EXTRACTION=low
 REASONING_EFFORT_SUMMARY=medium
 
-SLACK_BOT_TOKEN=xoxb- 
+SLACK_BOT_TOKEN=xoxb-
 CHANNEL_NAME=#disaster-alerts
+# Optional: separate channel for error/system notices (tracebacks, API
+# failures). When unset, such notices are logged only and never posted to
+# CHANNEL_NAME.
+#ERROR_CHANNEL_NAME=#disaster-alerts-ops
 
 JOB_INTERVAL_MINUTES=60
 

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 from fetch_feeds import fetch_rss_feeds, RSS_FEEDS
 from process_data import process_disasters
 from format_message import format_alert_block
-from send_to_slack import send_disaster_alert_block
+from send_to_slack import send_disaster_alert_block, send_error_notice
 import os
 from dotenv import load_dotenv
 import schedule
@@ -181,23 +181,16 @@ def job():
     except Exception as e:
         error_msg = f"An unexpected error occurred in the scheduled job: {str(e)}"
         logging.error(error_msg, exc_info=True)
-        
-        # Try to send error notification to Slack
+
+        # Notify via the error channel (or log only when none is configured) —
+        # tracebacks never go to the public alerts channel.
         try:
-            # Create a formatted error message with traceback
             import traceback
             tb_str = traceback.format_exc()
-            slack_error_message = f"⚠️ *System Alert:* The disaster monitoring system encountered an error:\n```\n{error_msg}\n\nTraceback:\n{tb_str[:800]}...\n```"
-            
-            send_disaster_alert_block([
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": slack_error_message
-                    }
-                }
-            ])
+            send_error_notice(
+                f"⚠️ *System Alert:* The disaster monitoring system encountered an error:\n"
+                f"```\n{error_msg}\n\nTraceback:\n{tb_str[:800]}...\n```"
+            )
         except Exception as slack_error:
             logging.error(f"Failed to send error notification to Slack: {slack_error}")
 

--- a/process_data.py
+++ b/process_data.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import datetime
 import logging
 import time
-from send_to_slack import send_disaster_alert_block
+from send_to_slack import send_error_notice
 from bs4 import BeautifulSoup
 
 # Load environment variables from .env file
@@ -643,17 +643,11 @@ def process_disasters(disasters, max_retries=3, backoff_factor=2):
             logging.info(f"Retrying in {sleep_time} seconds...")
             time.sleep(sleep_time)
 
-    # All retries exhausted — notify Slack once rather than on every attempt
+    # All retries exhausted — notify once, via the error channel (or log only)
     logging.error("Max retries reached. Failed to obtain summary from OpenAI.")
-    send_disaster_alert_block([
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"⚠️ *Alert:* Failed to obtain summary from OpenAI after {max_retries} attempts. Last error: {last_error}"
-            }
-        }
-    ])
+    send_error_notice(
+        f"⚠️ *Alert:* Failed to obtain summary from OpenAI after {max_retries} attempts. Last error: {last_error}"
+    )
     return None, "error"
 
 if __name__ == "__main__":

--- a/send_to_slack.py
+++ b/send_to_slack.py
@@ -14,31 +14,38 @@ load_dotenv()
 # Slack configuration
 SLACK_BOT_TOKEN = os.getenv('SLACK_BOT_TOKEN')
 CHANNEL_NAME = os.getenv('CHANNEL_NAME')
+# Optional separate channel for operational/error notices. When unset, error
+# notices are logged only — internal errors and tracebacks never go to the
+# public alerts channel.
+ERROR_CHANNEL_NAME = os.getenv('ERROR_CHANNEL_NAME')
 
 # Initialize Slack client
 client = WebClient(token=SLACK_BOT_TOKEN)
 
-def send_disaster_alert_block(blocks, max_retries=3, backoff_factor=2):
+def send_disaster_alert_block(blocks, max_retries=3, backoff_factor=2, channel=None):
     """
     Sends a Block Kit formatted message to Slack with retry logic.
-    
+
     Args:
         blocks (list): List of Slack Block Kit blocks
         max_retries (int): Maximum number of retry attempts
         backoff_factor (int): Factor for exponential backoff
-        
+        channel (str): Channel to post to (defaults to CHANNEL_NAME)
+
     Returns:
         bool: True if message was sent successfully, False otherwise
     """
+    channel = channel or CHANNEL_NAME
+
     # Validate required environment variables
     if not SLACK_BOT_TOKEN:
         logging.error("SLACK_BOT_TOKEN is not set in .env file")
         return False
-        
-    if not CHANNEL_NAME:
+
+    if not channel:
         logging.error("CHANNEL_NAME is not set in .env file")
         return False
-        
+
     # Generate a fallback text from the blocks for notifications
     fallback_text = "Disaster Alerts Summary"
     for block in blocks:
@@ -57,12 +64,12 @@ def send_disaster_alert_block(blocks, max_retries=3, backoff_factor=2):
             logging.debug(f"Sending blocks to Slack: {json.dumps(blocks, indent=2)}")
             
             response = client.chat_postMessage(
-                channel=CHANNEL_NAME,
+                channel=channel,
                 blocks=blocks,
                 text=fallback_text
             )
             
-            logging.info(f"Message sent successfully to {CHANNEL_NAME} (timestamp: {response['ts']})")
+            logging.info(f"Message sent successfully to {channel} (timestamp: {response['ts']})")
             return True
             
         except SlackApiError as e:
@@ -79,7 +86,7 @@ def send_disaster_alert_block(blocks, max_retries=3, backoff_factor=2):
                 try:
                     simplified_message = "⚠️ *Disaster Alert System*: New alerts detected, but there was an error formatting the message."
                     client.chat_postMessage(
-                        channel=CHANNEL_NAME,
+                        channel=channel,
                         text=simplified_message
                     )
                     logging.info("Sent simplified message after block formatting error")
@@ -91,11 +98,11 @@ def send_disaster_alert_block(blocks, max_retries=3, backoff_factor=2):
                 break
                 
             elif error_code == 'channel_not_found':
-                logging.error(f"Channel not found: {CHANNEL_NAME}")
+                logging.error(f"Channel not found: {channel}")
                 break  # Don't retry for non-existent channel
                 
             elif error_code == 'not_in_channel':
-                logging.error(f"Bot is not in channel: {CHANNEL_NAME}")
+                logging.error(f"Bot is not in channel: {channel}")
                 break  # Don't retry if bot isn't in the channel
                 
             elif error_code == 'rate_limited':
@@ -126,6 +133,35 @@ def send_disaster_alert_block(blocks, max_retries=3, backoff_factor=2):
                 logging.error("Max retries reached. Failed to send message to Slack.")
     
     return False
+
+def send_error_notice(text):
+    """
+    Send an operational/error notice.
+
+    Posts to ERROR_CHANNEL_NAME when configured; otherwise logs only. This
+    keeps internal errors and tracebacks out of the public alerts channel.
+
+    Args:
+        text (str): mrkdwn-formatted notice text
+
+    Returns:
+        bool: True if posted to Slack, False if logged only or send failed
+    """
+    if not ERROR_CHANNEL_NAME:
+        logging.error(f"System notice (ERROR_CHANNEL_NAME not set; not posted to Slack): {text}")
+        return False
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": text
+            }
+        }
+    ]
+    return send_disaster_alert_block(blocks, channel=ERROR_CHANNEL_NAME)
+
 
 # Simple test function for direct testing
 if __name__ == "__main__":


### PR DESCRIPTION
Tracebacks and OpenAI-failure notices previously posted to CHANNEL_NAME, the same public channel the disaster alerts go to. New send_error_notice() posts them to ERROR_CHANNEL_NAME when configured and only logs them otherwise; send_disaster_alert_block gains an optional channel parameter. Documented in .env.example.