### PR TITLE
Never round-trip URLs through the LLM; assemble alert messages determ…

### DIFF
--- a/format_message.py
+++ b/format_message.py
@@ -2,94 +2,81 @@
 
 import re
 
-def format_alert_block(summary):
+# Slack limits: 3000 chars of text per section block, 50 blocks per message.
+MAX_SECTION_LEN = 2900
+MAX_BLOCKS = 48  # leave room for the header and footer blocks
+
+
+def _pick_emoji(heading_text):
+    """Choose an emoji for a group heading based on disaster type keywords."""
+    checks = [
+        (r'earthquake', "🌍"),
+        (r'flood', "🌊"),
+        (r'fire|wildfire', "🔥"),
+        (r'hurricane|cyclone|typhoon', "🌀"),
+        (r'tornado', "🌪️"),
+        (r'storm|thunder|lightning', "⛈️"),
+        (r'volcano|eruption', "🌋"),
+        (r'snow|blizzard|winter', "❄️"),
+        (r'drought|heat', "☀️"),
+        (r'MD \d+|Discussion', "🌪️"),
+        (r'warning|advisory|watch', "⚠️"),
+    ]
+    for pattern, emoji in checks:
+        if re.search(pattern, heading_text, re.IGNORECASE):
+            return emoji
+    return "🌐"
+
+
+def _escape_mrkdwn(text):
+    """Escape Slack mrkdwn control characters in display text."""
+    return (
+        (text or "")
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _sanitize_url(url):
+    """Encode characters that would break Slack's <url|text> link syntax."""
+    return (url or "").replace("|", "%7C").replace(">", "%3E").replace(" ", "%20")
+
+
+def _item_line(item):
     """
-    Format the summary for Slack Block Kit with enhanced disaster-specific formatting.
-    
-    Includes:
-    1. Special emoji icons for different disaster types
-    2. Proper formatting for Slack's markdown
-    3. Handling of SPC MD messages and other special cases
+    Render one report as a single mrkdwn line. The link comes straight from
+    the source data — never from LLM output.
     """
+    title = _escape_mrkdwn(item.get("title", "No Title"))
+    url = _sanitize_url(item.get("link", ""))
+    source = _escape_mrkdwn(item.get("source", ""))
+    published = _escape_mrkdwn(item.get("published", ""))
 
-    # Add emoji based on disaster type in heading
-    def heading_replacer(match):
-        heading_text = match.group(1).strip()
-        
-        # Determine appropriate emoji based on disaster type
-        emoji = "🌐"  # Default emoji
-        
-        if re.search(r'earthquake', heading_text, re.IGNORECASE):
-            emoji = "🌍"  # Changed from 🌋 to 🌍 for earthquake
-        elif re.search(r'flood', heading_text, re.IGNORECASE):
-            emoji = "🌊"
-        elif re.search(r'fire|wildfire', heading_text, re.IGNORECASE):
-            emoji = "🔥"
-        elif re.search(r'hurricane|cyclone|typhoon', heading_text, re.IGNORECASE):
-            emoji = "🌀"
-        elif re.search(r'tornado', heading_text, re.IGNORECASE):
-            emoji = "🌪️"
-        elif re.search(r'storm|thunder|lightning', heading_text, re.IGNORECASE):
-            emoji = "⛈️"
-        elif re.search(r'volcano|eruption', heading_text, re.IGNORECASE):
-            emoji = "🌋"
-        elif re.search(r'snow|blizzard|winter', heading_text, re.IGNORECASE):
-            emoji = "❄️"
-        elif re.search(r'drought|heat', heading_text, re.IGNORECASE):
-            emoji = "☀️"
-        elif re.search(r'MD \d+|Discussion', heading_text, re.IGNORECASE):
-            emoji = "🌪️"  # SPC Mesoscale Discussions often relate to severe weather
-        elif re.search(r'warning|advisory|watch', heading_text, re.IGNORECASE):
-            emoji = "⚠️"
-            
-        return f"*{emoji} {heading_text}*"
+    line = f"• <{url}|{title}>" if url else f"• {title}"
+    meta = " — ".join(p for p in (published, source) if p)
+    if meta:
+        line += f"  ({meta})"
+    return line
 
-    # Special handling for SPC MD messages - add emoji for weather alerts
-    summary = re.sub(
-        r"^\s*###\s+(SPC MD \d+)", 
-        r"### 🌪️ \1", 
-        summary,
-        flags=re.MULTILINE
-    )
 
-    # 2. Turn lines starting with '### ' into bold lines with emoji
-    summary = re.sub(
-        r'^\s*###\s+(.*)',
-        heading_replacer,
-        summary,
-        flags=re.MULTILINE
-    )
+def _section(text):
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
 
-    # 3. Convert '**some text**' into '*some text*' for Slack bold
-    summary = re.sub(
-        r'\*\*(.+?)\*\*',
-        r'*\1*',
-        summary
-    )
-    
-    # 4. Fix Slack link formatting - ensure proper format <url|text>
-    # A link with a missing URL (<|More Info>) is invalid Block Kit and would
-    # be rejected by Slack; degrade it to plain text instead.
-    summary = re.sub(
-        r'<\|(More Info)>',
-        r'\1',
-        summary
-    )
 
-    # Also fix any markdown links [text](url)
-    summary = re.sub(
-        r'\[([^\]]+)\]\(([^)]+)\)',
-        r'<\2|\1>',
-        summary
-    )
+def format_alert_block(groups):
+    """
+    Format structured alert groups into Slack Block Kit blocks.
 
-    # Create blocks with dividers between sections. Slack limits: 3000 chars
-    # of text per section block, 50 blocks per message. Truncate per section
-    # (not globally) so a busy day drops detail, not whole disaster groups.
-    max_section_len = 2900
-    max_blocks = 48  # leave room for the header and footer blocks
+    Args:
+        groups: list of {"heading": str, "summary": str, "items": [
+                    {"title", "link", "published", "source"}, ...]}
+                as produced by process_disasters().
 
-    sections = [s.strip() for s in summary.split('---') if s.strip()]
+    Text is packed into section blocks at line granularity — a line (and
+    therefore a link) is never split mid-way. Groups that do not fit within
+    Slack's 50-block limit are omitted and counted in the footer.
+    """
     blocks = [
         {
             "type": "header",
@@ -102,27 +89,39 @@ def format_alert_block(summary):
     ]
 
     truncated_groups = 0
-    for i, section in enumerate(sections):
-        if len(blocks) >= max_blocks:
-            truncated_groups = len(sections) - i
+    for gi, group in enumerate(groups):
+        if len(blocks) >= MAX_BLOCKS:
+            truncated_groups = len(groups) - gi
             break
 
-        if len(section) > max_section_len:
-            section = section[:max_section_len] + "..."
+        heading = group.get("heading") or "Alerts"
+        emoji = _pick_emoji(heading)
+        lines = [f"*{emoji} {_escape_mrkdwn(heading)}*"]
+        summary = (group.get("summary") or "").strip()
+        if summary:
+            lines.append(_escape_mrkdwn(summary))
+        lines.extend(_item_line(item) for item in group.get("items", []))
 
-        blocks.append({
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": section
-            }
-        })
+        # Pack whole lines into section blocks (an over-long single line is
+        # truncated on its own, which can shorten displayed text but never
+        # produces a dangling half-link followed by other content).
+        current = ""
+        for line in lines:
+            if len(line) > MAX_SECTION_LEN:
+                line = line[:MAX_SECTION_LEN] + "…"
+            if current and len(current) + 1 + len(line) > MAX_SECTION_LEN:
+                if len(blocks) >= MAX_BLOCKS:
+                    break
+                blocks.append(_section(current))
+                current = line
+            else:
+                current = f"{current}\n{line}" if current else line
+        if current and len(blocks) < MAX_BLOCKS:
+            blocks.append(_section(current))
 
-        # Add a divider after each section except the last one
-        if i < len(sections) - 1 and len(blocks) < max_blocks:
+        if gi < len(groups) - 1 and len(blocks) < MAX_BLOCKS:
             blocks.append({"type": "divider"})
 
-    # Add footer
     footer_text = "Disaster Alert Monitor"
     if truncated_groups:
         footer_text += f" — {truncated_groups} additional group(s) omitted (message limit)"

--- a/main.py
+++ b/main.py
@@ -144,13 +144,13 @@ def main():
     
     logging.info(f"Processing {len(new_disasters)} new disaster reports.")
     
-    # Process and summarize the disasters
-    summary, status = process_disasters(new_disasters)
+    # Process and summarize the disasters into structured groups
+    groups, status = process_disasters(new_disasters)
     new_links = [d['link'] for d in new_disasters]
 
-    if status == "ok" and summary:
+    if status == "ok" and groups:
         # Format and send the alert to Slack
-        formatted_blocks = format_alert_block(summary)
+        formatted_blocks = format_alert_block(groups)
         logging.debug("Formatted blocks to be sent to Slack:")
         logging.debug(json.dumps(formatted_blocks, indent=2))
 

--- a/process_data.py
+++ b/process_data.py
@@ -533,16 +533,60 @@ def group_disasters(disasters):
     
     return grouped
 
+def _items_for_group(reports):
+    """Build display items (title/link/published/source) straight from source data."""
+    return [
+        {
+            "title": r.get("title", "No Title"),
+            "link": r.get("link", "") or "",
+            "published": r.get("published", ""),
+            "source": r.get("source", "Unknown Source"),
+        }
+        for r in reports
+    ]
+
+
+def _fallback_group(key, reports):
+    """Deterministic group rendering used when the LLM is unavailable or omits a group."""
+    details = reports[0].get("details", {}) if reports else {}
+    parts = []
+    dtype = details.get("disaster_type")
+    location = details.get("location")
+    date = details.get("date")
+    severity = details.get("severity")
+    if dtype and dtype != "Unknown Type":
+        parts.append(f"{dtype}")
+    if location and location != "Unknown Location":
+        parts.append(f"in {location}")
+    if date and date != "Unknown Date":
+        parts.append(f"on {date}")
+    sentence = " ".join(parts).capitalize() + "." if parts else ""
+    if severity:
+        sentence += f" Severity: {severity}."
+    return {
+        "heading": key,
+        "summary": sentence or f"{len(reports)} report(s).",
+        "items": _items_for_group(reports),
+    }
+
+
 def process_disasters(disasters, max_retries=3, backoff_factor=2):
     """
-    Process disasters by grouping and preparing summaries.
-    Implements retries with exponential backoff for OpenAI API calls.
+    Process disasters by grouping and preparing structured alert groups.
+
+    The LLM is used ONLY to merge related groups and write narrative
+    summaries — it never sees or emits URLs. Item lines (title, link,
+    published, source) are attached in code from the source data, so links
+    cannot be hallucinated or mangled in the LLM round-trip.
 
     Returns:
-        tuple: (summary, status) where status is one of:
-            "ok"    - summary generated successfully
+        tuple: (groups, status) where groups is a list of
+            {"heading": str, "summary": str, "items": [
+                {"title", "link", "published", "source"}, ...]}
+        and status is one of:
+            "ok"    - groups ready to send (possibly deterministic fallback)
             "empty" - nothing left after filtering (entries can be marked as sent)
-            "error" - LLM summarization failed (entries should be retried next run)
+            "error" - grouping produced nothing sendable
     """
     grouped = group_disasters(disasters)
 
@@ -551,80 +595,63 @@ def process_disasters(disasters, max_retries=3, backoff_factor=2):
         logging.info("No disasters to process after filtering")
         return None, "empty"
 
-    # Prepare the prompt for the LLM
-    prompt = """
-    You are an assistant that processes disaster reports and formats them for a Slack workspace. 
-    De-duplicate and aggregate by disaster type. For each disaster, provide a summary including key details and links.
-    
-    IMPORTANT FORMAT REQUIREMENTS:
-    1. For each disaster group, print a line starting with '### ' followed by the group name.
-    2. Then provide a brief 1-2 sentence summary that includes:
-       - What happened (disaster type)
-       - Where it happened (specific location)
-       - When it happened (date)
-       - How severe it was (magnitude, category, etc. if available)
-       - For GDACS alerts, include the alert level (Orange or Red)
-    3. Then, for each item in that group, print bullet lines that start with '- **Title:**' followed by the item title. Then new lines for:
-       - **Published:**
-       - **Source:**
-       - **Link:**
-    4. Separate each group with a line that only contains three dashes: '---'.
-    5. Do NOT add extra headings or emojis outside of each group. End after listing all groups.
-    
-    <Here is the grouped data...>
-    """
+    # Compact, URL-free description of the groups for the LLM
+    payload = []
+    for key, reports in grouped.items():
+        details = reports[0].get("details", {}) if reports else {}
+        payload.append({
+            "key": key,
+            "details": {k: v for k, v in details.items() if v},
+            "titles": [r.get("title", "") for r in reports],
+        })
 
-    for group, reports in grouped.items():
-        prompt += f"\n### {group}\n"
-        
-        # Include extracted details in the prompt
-        if reports and "details" in reports[0]:
-            details = reports[0]["details"]
-            prompt += "Extracted details:\n"
-            for key, value in details.items():
-                if value:  # Only include non-empty values
-                    prompt += f"- {key}: {value}\n"
-            prompt += "\n"
-        
-        for report in reports:
-            # Format with Slack-style links using <URL|Link Text>
-            link_text = "More Info"
-            # Ensure the link is properly formatted with no pipe character in URL
-            url = report.get('link', '#')
-            # Double check the URL is valid (not empty and does not already contain a pipe)
-            if not url or url == '#':
-                url = 'https://example.com/no-link-available'
-            url = url.replace('%7C', '%7c').replace('|', '%7c')  # Replace any pipe chars with encoded version
-            
-            formatted_link = f"<{url}|{link_text}>"
-            prompt += (f"- **Title:** {report.get('title', 'No Title')}\n"
-                      f"  - **Published:** {report.get('published', 'No Published Date')}\n"
-                      f"  - **Source:** {report.get('source', 'Unknown Source')}\n"
-                      f"  - **Link:** {formatted_link}\n")
-        prompt += "---\n"
-    prompt += "\nAggregated Summary:"
+    prompt = f"""
+You are aggregating disaster reports for a Slack alert.
 
-    # Log the prompt for debugging
+Below is a JSON list of disaster report groups. Merge groups that describe the
+same event or belong naturally together (e.g. several reports of one
+earthquake, or many wildfires in one region), and write a concise 1-2 sentence
+summary for each merged group covering: what happened, where, when, and how
+severe (magnitude, acreage, category; include GDACS alert level Orange/Red
+when present).
+
+Return ONLY valid JSON in this exact structure:
+{{"groups": [{{"heading": "Short heading", "summary": "1-2 sentences.", "member_keys": ["<key>", "<key>"]}}]}}
+
+Rules:
+- member_keys must echo input "key" values EXACTLY, character for character.
+- Every input key must appear in exactly one group's member_keys.
+- Do NOT include URLs or links anywhere.
+- Headings are short and specific, e.g. "Wildfires — Western US" or
+  "Earthquake (M6.4) — Papua New Guinea".
+
+Input groups:
+{json.dumps(payload, indent=1)}
+"""
+
     logging.debug(f"Prompt sent to OpenAI:\n{prompt}")
 
-    # Call OpenAI's API with retries using the new Responses API
+    llm_groups = None
+    last_error = "unknown"
     for attempt in range(1, max_retries + 1):
         try:
             response = client.responses.create(
                 model=MODEL_NAME,
                 reasoning={"effort": REASONING_EFFORT_SUMMARY},
-                instructions="You process disaster alert data and format it for concise, informative Slack messages. Focus on providing clear what/where/when information.",
+                instructions="You aggregate disaster alert data into concise group summaries. Return ONLY valid JSON matching the requested structure. Never include URLs.",
                 input=prompt,
             )
-            # Access the response using the new format
-            summary = response.output_text.strip()
-
-            logging.info("Successfully obtained summary from OpenAI.")
-
-            # Log the summary for debugging
-            logging.debug(f"Raw LLM summary:\n{summary}")
-
-            return summary, "ok"
+            parsed = json.loads(strip_json_fences(response.output_text))
+            candidate = parsed.get("groups")
+            if isinstance(candidate, list) and candidate:
+                llm_groups = candidate
+                logging.info("Successfully obtained group summaries from OpenAI.")
+                break
+            last_error = "LLM returned JSON without a usable 'groups' list."
+            logging.error(f"Attempt {attempt}: {last_error}")
+        except json.JSONDecodeError as e:
+            last_error = f"LLM returned unparseable JSON: {e}"
+            logging.error(f"Attempt {attempt}: {last_error}")
         except RateLimitError as e:
             last_error = "OpenAI API request exceeded rate limit. Please check your quota."
             logging.error(f"Attempt {attempt}: OpenAI API request exceeded rate limit: {e}")
@@ -643,18 +670,62 @@ def process_disasters(disasters, max_retries=3, backoff_factor=2):
             logging.info(f"Retrying in {sleep_time} seconds...")
             time.sleep(sleep_time)
 
-    # All retries exhausted — notify once, via the error channel (or log only)
-    logging.error("Max retries reached. Failed to obtain summary from OpenAI.")
-    send_error_notice(
-        f"⚠️ *Alert:* Failed to obtain summary from OpenAI after {max_retries} attempts. Last error: {last_error}"
-    )
-    return None, "error"
+    result = []
+    used_keys = set()
+
+    if llm_groups:
+        for g in llm_groups:
+            if not isinstance(g, dict):
+                continue
+            keys = [
+                k for k in (g.get("member_keys") or [])
+                if k in grouped and k not in used_keys
+            ]
+            if not keys:
+                continue
+            used_keys.update(keys)
+            items = []
+            for k in keys:
+                items.extend(_items_for_group(grouped[k]))
+            result.append({
+                "heading": (g.get("heading") or keys[0]).strip(),
+                "summary": (g.get("summary") or "").strip(),
+                "items": items,
+            })
+
+    # Any groups the LLM omitted or mangled the keys of — and, when the LLM
+    # failed entirely, every group — are rendered deterministically. An alert
+    # system should degrade to plainer messages, not to silence.
+    leftover = [k for k in grouped if k not in used_keys]
+    if leftover:
+        if llm_groups:
+            logging.warning(
+                f"LLM response omitted {len(leftover)} group(s); rendering them deterministically."
+            )
+        else:
+            logging.error(
+                f"LLM summarization failed after {max_retries} attempts ({last_error}); "
+                f"sending deterministic fallback for all {len(leftover)} group(s)."
+            )
+            send_error_notice(
+                f"⚠️ *Alert:* Group summarization failed after {max_retries} attempts "
+                f"(last error: {last_error}). Alerts were sent in deterministic fallback format."
+            )
+        for k in leftover:
+            result.append(_fallback_group(k, grouped[k]))
+
+    if not result:
+        return None, "error"
+    return result, "ok"
 
 if __name__ == "__main__":
     from fetch_feeds import RSS_FEEDS
     disasters = fetch_rss_feeds(RSS_FEEDS)
-    summary, status = process_disasters(disasters)
-    if summary:
-        print(summary)
+    groups, status = process_disasters(disasters)
+    if groups:
+        for g in groups:
+            print(f"== {g['heading']}\n{g['summary']}")
+            for item in g["items"]:
+                print(f"  - {item['title']} | {item['link']}")
     else:
-        print(f"No summary generated (status: {status}).")
+        print(f"No groups generated (status: {status}).")


### PR DESCRIPTION
…inistically

The first production WFIGS alert showed the failure: item links are embedded in the summarization prompt and the model reproduces them in its output — all but the first came back subtly corrupted (wrong slugs render as blank InciWeb pages), and the per-section truncation could additionally cut a message mid-URL.

process_disasters now returns structured groups. The LLM's only job is merging related groups and writing narrative summaries from a URL-free payload of keys/details/titles; item lines (title, link, published, source) are attached in code from source data. Groups whose keys the LLM omits or mangles are rendered deterministically, and a total LLM failure degrades to plain deterministic groups with a single error notice — an alert system should degrade to plainer messages, not to silence.

format_alert_block renders the structured groups directly (no regex parsing of LLM markdown), packs text into section blocks at line granularity so a link is never split, escapes mrkdwn in feed-derived text, and keeps the 50-block/3000-char Slack limits with an explicit "omitted" footer.