### PR TITLE
Link WFIGS incidents to map pins; constructed InciWeb URLs are not vi…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,10 @@ RSS_FEED_2=https://api.reliefweb.int/v2/disasters?appname=YOUR-APPNAME&limit=20&
 # InciWeb: the RSS endpoint (inciweb.wildfire.gov/incidents/rss.xml) is
 # WAF-blocked for datacenter IPs. NIFC's WFIGS ArcGIS service is the
 # authoritative dataset behind it and is open; tune the significance
-# threshold via poly_GISAcres in the where clause.
-RSS_FEED_3=https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query?where=attr_IncidentTypeCategory%3D%27WF%27+AND+poly_GISAcres+%3E%3D+1000+AND+%28attr_PercentContained+%3C+95+OR+attr_PercentContained+IS+NULL%29&outFields=attr_IncidentName,attr_UniqueFireIdentifier,attr_POOState,attr_POOCounty,poly_GISAcres,attr_PercentContained,attr_FireDiscoveryDateTime,attr_ModifiedOnDateTime_dt&orderByFields=attr_ModifiedOnDateTime_dt+DESC&resultRecordCount=50&f=json
+# threshold via poly_GISAcres in the where clause. Incident links are map
+# pins from InitialLatitude/InitialLongitude (InciWeb page URLs are not
+# derivable — most WFIGS incidents have no published InciWeb page).
+RSS_FEED_3=https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query?where=attr_IncidentTypeCategory%3D%27WF%27+AND+poly_GISAcres+%3E%3D+1000+AND+%28attr_PercentContained+%3C+95+OR+attr_PercentContained+IS+NULL%29&outFields=attr_IncidentName,attr_UniqueFireIdentifier,attr_POOState,attr_POOCounty,poly_GISAcres,attr_PercentContained,attr_FireDiscoveryDateTime,attr_ModifiedOnDateTime_dt,attr_InitialLatitude,attr_InitialLongitude&orderByFields=attr_ModifiedOnDateTime_dt+DESC&resultRecordCount=50&f=json
 RSS_FEED_4=http://www.spc.noaa.gov/products/spcrss.xml
 RSS_FEED_5=https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.atom
 RSS_FEED_6=https://www.nhc.noaa.gov/gtwo.xml

--- a/fetch_feeds.py
+++ b/fetch_feeds.py
@@ -113,20 +113,20 @@ def fetch_reliefweb_api(feed_url, headers):
     return reports
 
 
-def _wfigs_inciweb_link(unique_fire_id, incident_name):
+def _wfigs_map_link(lat, lon):
     """
-    Construct the InciWeb incident page URL from WFIGS identifiers.
+    Link a WFIGS incident to a map pin at its discovery coordinates.
 
-    InciWeb slugs are '{unit-code}-{name-slug}' (e.g. nveld-parsnip-peak) and
-    UniqueFireIdentifier is 'YYYY-UNITCODE-NNNNNN'. Verified 15/15 against live
-    incidents 2026-07-14. Falls back to the InciWeb homepage when the unit
-    code cannot be parsed.
+    Constructed InciWeb URLs are NOT viable: WFIGS tracks every incident but
+    InciWeb only publishes pages for team-managed ones (the rest render as
+    empty stubs), and even published incidents may live at unpredictable slug
+    variants (e.g. 'orwwf-anthony-fire' for incident 'Anthony'). A coordinate
+    pin always resolves. Coordinates are rounded to 4 decimals so the link is
+    deterministic run-to-run (it is also the dedup key).
     """
-    m = re.match(r"\d{4}-([A-Za-z0-9]+)-", unique_fire_id or "")
-    name_slug = re.sub(r"[^a-z0-9]+", "-", (incident_name or "").lower()).strip("-")
-    if not (m and name_slug):
+    if lat is None or lon is None:
         return "https://inciweb.wildfire.gov/"
-    return f"https://inciweb.wildfire.gov/incident-information/{m.group(1).lower()}-{name_slug}"
+    return f"https://www.google.com/maps/search/?api=1&query={lat:.4f},{lon:.4f}"
 
 
 def fetch_wfigs_incidents(feed_url, headers):
@@ -159,22 +159,34 @@ def fetch_wfigs_incidents(feed_url, headers):
         name = a.get("attr_IncidentName") or a.get("IncidentName") or "Unnamed incident"
         state = a.get("attr_POOState") or a.get("POOState") or ""
         county = a.get("attr_POOCounty") or a.get("POOCounty") or ""
-        acres = a.get("poly_GISAcres") or a.get("DailyAcres")
-        contained = a.get("attr_PercentContained") or a.get("PercentContained")
-        ufi = a.get("attr_UniqueFireIdentifier") or a.get("UniqueFireIdentifier") or ""
+        def attr(*names):
+            for n in names:
+                if a.get(n) is not None:
+                    return a[n]
+            return None
+
+        acres = attr("poly_GISAcres", "DailyAcres")
+        contained = attr("attr_PercentContained", "PercentContained")
+        lat = attr("attr_InitialLatitude", "InitialLatitude")
+        lon = attr("attr_InitialLongitude", "InitialLongitude")
 
         title = f"{name} Fire" if not name.lower().endswith(("fire", "complex")) else name
         if state:
             title += f" ({state})"
 
-        summary_parts = ["Active wildfire."]
+        # Compact stats shown on the item line itself — the link is only a
+        # map pin, so the substance must be in the message.
+        note_parts = []
         if acres:
-            summary_parts.append(f"Approximately {round(acres):,} acres.")
+            note_parts.append(f"~{round(acres):,} acres")
         if contained is not None:
-            summary_parts.append(f"{round(contained)}% contained.")
+            note_parts.append(f"{round(contained)}% contained")
         loc = ", ".join(p for p in (county and f"{county} County", state) if p)
         if loc:
-            summary_parts.append(f"Location: {loc}.")
+            note_parts.append(loc)
+        note = ", ".join(note_parts)
+
+        summary = "Active wildfire." + (f" {note}." if note else "")
 
         # WFIGS timestamps are epoch milliseconds
         published = ""
@@ -186,10 +198,11 @@ def fetch_wfigs_incidents(feed_url, headers):
 
         reports.append({
             "title": title,
-            "summary": " ".join(summary_parts),
-            "link": _wfigs_inciweb_link(ufi, name),
+            "summary": summary,
+            "note": note,
+            "link": _wfigs_map_link(lat, lon),
             "published": published,
-            "source": "InciWeb (via NIFC WFIGS)",
+            "source": "NIFC WFIGS",
             "source_type": "inciweb",
             "raw_entry": a,
         })

--- a/format_message.py
+++ b/format_message.py
@@ -50,10 +50,13 @@ def _item_line(item):
     """
     title = _escape_mrkdwn(item.get("title", "No Title"))
     url = _sanitize_url(item.get("link", ""))
+    note = _escape_mrkdwn(item.get("note", ""))
     source = _escape_mrkdwn(item.get("source", ""))
     published = _escape_mrkdwn(item.get("published", ""))
 
     line = f"• <{url}|{title}>" if url else f"• {title}"
+    if note:
+        line += f" — {note}"
     meta = " — ".join(p for p in (published, source) if p)
     if meta:
         line += f"  ({meta})"

--- a/process_data.py
+++ b/process_data.py
@@ -534,11 +534,12 @@ def group_disasters(disasters):
     return grouped
 
 def _items_for_group(reports):
-    """Build display items (title/link/published/source) straight from source data."""
+    """Build display items (title/link/note/published/source) straight from source data."""
     return [
         {
             "title": r.get("title", "No Title"),
             "link": r.get("link", "") or "",
+            "note": r.get("note", ""),
             "published": r.get("published", ""),
             "source": r.get("source", "Unknown Source"),
         }


### PR DESCRIPTION
…able

Production showed that slug-constructed InciWeb links mostly land on empty stubs: WFIGS tracks every incident but InciWeb only publishes pages for team-managed ones, and even published incidents can live at unpredictable slug variants (orwwf-anthony-fire for incident "Anthony"). No WFIGS attribute predicts publishedness (ICS209 presence: 29 false positives in 31), so InciWeb page links cannot be derived reliably.

Each incident now links to a coordinate map pin built from InitialLatitude/InitialLongitude (100% coverage, deterministic, unique per fire — safe as dedup key), and the item line carries the substance inline via a new optional note field: acreage, containment, county. Source label becomes "NIFC WFIGS". Also fix 0% containment being dropped as falsy.